### PR TITLE
Feature/options-refactor

### DIFF
--- a/examples/tests.php
+++ b/examples/tests.php
@@ -397,10 +397,11 @@ function wp_backstage_init() {
 	) );
 
 	WP_Backstage_Options::add( 'wp_backstage_options', array( 
-		'title'        => __( 'Test Options', 'wp_backstage' ), 
-		'menu_title'   => __( 'Test Options', 'wp_backstage' ), 
-		'description'  => __( 'A test custom options page containing all field types.', 'wp_backstage' ), 
-		'show_in_rest' => true, 
+		'title'             => __( 'Test Options', 'wp_backstage' ), 
+		'menu_title'        => __( 'Test Options', 'wp_backstage' ), 
+		'description'       => __( 'A test custom options page containing all field types.', 'wp_backstage' ), 
+		'show_in_rest'      => true, 
+		'group_options_key' => 'wp_backstage_options', 
 		'sections' => array(
 			array(
 				'id'          => 'wp_backstage_options_fields', 

--- a/includes/class-wp-backstage-options.php
+++ b/includes/class-wp-backstage-options.php
@@ -416,7 +416,7 @@ class WP_Backstage_Options extends WP_Backstage {
 
 	}
 
-	public function render_page() { var_dump( get_option( $this->args['group_options_key'] ) ); ?>
+	public function render_page() { ?>
 
 		<div class="wrap">
 

--- a/includes/class-wp-backstage-options.php
+++ b/includes/class-wp-backstage-options.php
@@ -110,16 +110,6 @@ class WP_Backstage_Options extends WP_Backstage {
 
 		}
 
-		/*if ( ! empty( $this->args['sections'] ) ) {
-			foreach ( $this->args['sections'] as $section_index => $section ) {
-				if ( ! empty( $section['fields'] ) ) {
-					foreach ( $section['fields'] as $field_index => $field ) {
-						$this->args['sections'][$section_index]['fields'][$field_index]['name'] = sprintf( '%1$s[%2$s]', $this->slug, $field['name'] );
-					}
-				}
-			}
-		}*/
-
 	}
 
 	/**
@@ -232,8 +222,6 @@ class WP_Backstage_Options extends WP_Backstage {
 				} 
 
 			}
-
-			// update_option( $this->args['group_options_key'], $values );
 
 		}
 

--- a/includes/class-wp-backstage-options.php
+++ b/includes/class-wp-backstage-options.php
@@ -21,11 +21,12 @@ class WP_Backstage_Options extends WP_Backstage {
 	 * @since 0.0.1
 	 */
 	public $default_args = array(
-		'title'        => '', 
-		'menu_title'   => '', 
-		'description'  => '', 
-		'capability'   => 'manage_options', 
-		'sections' => array(), 
+		'title'             => '', 
+		'menu_title'        => '', 
+		'description'       => '', 
+		'capability'        => 'manage_options', 
+		'group_options_key' => '', 
+		'sections'          => array(), 
 	);
 
 	/**
@@ -109,7 +110,7 @@ class WP_Backstage_Options extends WP_Backstage {
 
 		}
 
-		if ( ! empty( $this->args['sections'] ) ) {
+		/*if ( ! empty( $this->args['sections'] ) ) {
 			foreach ( $this->args['sections'] as $section_index => $section ) {
 				if ( ! empty( $section['fields'] ) ) {
 					foreach ( $section['fields'] as $field_index => $field ) {
@@ -117,7 +118,7 @@ class WP_Backstage_Options extends WP_Backstage {
 					}
 				}
 			}
-		}
+		}*/
 
 	}
 
@@ -203,6 +204,43 @@ class WP_Backstage_Options extends WP_Backstage {
 
 	}
 
+	public function save() {
+
+		if ( empty( $this->args['group_options_key'] ) ) {
+			return null;
+		}
+		
+		$fields = $this->get_fields();
+		$values = array();
+
+		if ( is_array( $fields ) && ! empty( $fields ) ) {
+
+			foreach ( $fields as $field ) {
+
+				if ( isset( $_POST[$field['name']] ) ) {
+
+					$value = $this->sanitize_field( $field, $_POST[$field['name']] );
+
+					$values[$field['name']] = $value;
+
+				} elseif ( in_array( $field['type'], array( 'checkbox', 'checkbox_set', 'radio' ) ) ) {
+
+					$value = ( $field['type'] === 'radio' ) ? '' : false;
+
+					$values[$field['name']] = $value;
+
+				} 
+
+			}
+
+			// update_option( $this->args['group_options_key'], $values );
+
+		}
+
+		return $values;
+
+	} 
+
 	/**
 	 * Add Settings
 	 * 
@@ -212,18 +250,20 @@ class WP_Backstage_Options extends WP_Backstage {
 	public function add_settings() {
 
 		$sections = $this->get_sections();
-		$fields = array();
-		$values = get_option( $this->slug );
 
-		register_setting(
-			$this->slug, 
-			$this->slug, 
-			array(
-				'description'       => wp_kses( $this->args['description'], $this->kses_p ), 
-				'show_in_rest'      => $this->args['show_in_rest'], 
-				'sanitize_callback' => array( $this, 'save' ),  
-			)
-		);
+		if ( ! empty( $this->args['group_options_key'] ) ) {
+
+			register_setting(
+				$this->slug, 
+				$this->args['group_options_key'], 
+				array(
+					'description'       => wp_kses( $this->args['description'], $this->kses_p ), 
+					'show_in_rest'      => $this->args['show_in_rest'], // TODO: Maybe make per field rest option?
+					'sanitize_callback' => array( $this, 'save' ), 
+				)
+			);
+
+		}
 
 		if ( is_array( $sections ) && ! empty( $sections ) ) {
 			
@@ -242,8 +282,7 @@ class WP_Backstage_Options extends WP_Backstage {
 
 						$field = wp_parse_args( $field, $this->default_field_args );
 						$field_id = sanitize_title_with_dashes( $field['name'] );
-						$field_key = $this->format_field_key( $field['name'] );
-						$field['value'] = isset( $values[$field_key] ) ? $values[$field_key] : null;
+						$field['value'] = get_option( $field['name'] );
 						$field['show_label'] = false;
 						$input_class = isset( $field['input_attrs']['class'] ) ? $field['input_attrs']['class'] : '';
 
@@ -255,6 +294,16 @@ class WP_Backstage_Options extends WP_Backstage {
 							$field['input_attrs']['rows'] = isset( $field['input_attrs']['rows'] ) ? $field['input_attrs']['rows'] : 5;
 							$field['input_attrs']['cols'] = isset( $field['input_attrs']['cols'] ) ? $field['input_attrs']['cols'] : 90;
 						}
+
+						register_setting(
+							$this->slug, 
+							$field['name'], 
+							array(
+								'description'       => wp_kses( $field['description'], $this->kses_p ), 
+								'show_in_rest'      => $this->args['show_in_rest'], // TODO: Maybe make per field rest option?
+								'sanitize_callback' => array( $this, $this->get_sanitize_callback( $field ) ), 
+							)
+						);
 
 						add_settings_field( 
 							$field['name'],  
@@ -276,58 +325,6 @@ class WP_Backstage_Options extends WP_Backstage {
 			}
 
 		}
-
-	}
-
-	/**
-	 * Save
-	 * 
-	 * @since   0.0.1
-	 * @return  void 
-	 */
-	public function save( $data = array() ) {
-
-		$fields = $this->get_fields();
-
-		$values = array();
-
-		if ( is_array( $fields ) && ! empty( $fields ) ) {
-
-			foreach ( $fields as $field ) {
-
-				$field_key = $this->format_field_key( $field['name'] );
-
-				if ( isset( $data[$field_key] ) ) {
-
-					$value = $this->sanitize_field( $field, $data[$field_key] );
-
-					update_option( $field_key, $value );
-
-					$values[$field_key] = $value;
-
-				} elseif ( in_array( $field['type'], array( 'checkbox', 'checkbox_set', 'radio' ) ) ) {
-
-					$value = ( $field['type'] === 'radio' ) ? '' : false;
-
-					update_option( $field_key, $value );
-
-					$values[$field_key] = $value;
-
-				} 
-
-			}
-
-		}
-
-		return $values;
-
-	}
-
-	public function format_field_key( $name = '' ) {
-
-		$pattern = '/^' . $this->slug . '\[|\]$/';
-
-		return preg_replace( $pattern, '', $name );
 
 	}
 
@@ -431,7 +428,7 @@ class WP_Backstage_Options extends WP_Backstage {
 
 	}
 
-	public function render_page() { ?>
+	public function render_page() { var_dump( get_option( $this->args['group_options_key'] ) ); ?>
 
 		<div class="wrap">
 
@@ -520,24 +517,6 @@ class WP_Backstage_Options extends WP_Backstage {
 
 		return $fields;
 
-	}
-
-	public function add_admin_head_style_action() {
-		
-		if ( ! $this->is_screen( 'id', $this->screen_id ) ) {
-			return;
-		}
-
-		do_action( $this->format_head_style_action( $this->slug ) );
-	}
-
-	public function add_admin_footer_script_action() {
-		
-		if ( ! $this->is_screen( 'id', $this->screen_id ) ) {
-			return;
-		}
-
-		do_action( $this->format_footer_script_action( $this->slug ) );
 	}
 
 }

--- a/includes/class-wp-backstage-user.php
+++ b/includes/class-wp-backstage-user.php
@@ -9,6 +9,13 @@
 class WP_Backstage_User extends WP_Backstage {
 
 	/**
+	 * Slug
+	 * 
+	 * @since 0.0.1
+	 */
+	public $slug = 'user';
+
+	/**
 	 * Default Args
 	 * 
 	 * @since 0.0.1
@@ -145,8 +152,8 @@ class WP_Backstage_User extends WP_Backstage {
 		add_filter( 'manage_users_sortable_columns', array( $this, 'manage_sortable_columns' ), 10 );
 		add_filter( 'manage_users_custom_column', array( $this, 'manage_admin_column_content' ), 10, 3 );
 		add_action( 'pre_get_users', array( $this, 'manage_sorting' ), 10 );
-		$this->hook_inline_styles( 'user' );
-		$this->hook_inline_scripts( 'user' );
+		$this->hook_inline_styles( $this->slug );
+		$this->hook_inline_scripts( $this->slug );
 
 		parent::init();
 
@@ -308,11 +315,11 @@ class WP_Backstage_User extends WP_Backstage {
 
 					<td><?php 
 
-						do_action( $this->format_field_action( 'user', 'before' ), $field, $user );
+						do_action( $this->format_field_action( $this->slug, 'before' ), $field, $user );
 
 						$this->render_field_by_type( $field ); 
 
-						do_action( $this->format_field_action( 'user', 'after' ), $field, $user );
+						do_action( $this->format_field_action( $this->slug, 'after' ), $field, $user );
 
 					?></td>
 
@@ -390,7 +397,7 @@ class WP_Backstage_User extends WP_Backstage {
 			$value = get_user_meta( $user_id, $column, true );
 
 			// short circuit the column content and allow developer to add their own.
-			$content = apply_filters( $this->format_column_content_filter( 'user', $column ), $content, $field, $value, $user_id );
+			$content = apply_filters( $this->format_column_content_filter( $this->slug, $column ), $content, $field, $value, $user_id );
 			if ( ! empty( $content ) ) {
 				return $content;
 			}
@@ -453,24 +460,6 @@ class WP_Backstage_User extends WP_Backstage {
 
 		}
 
-	}
-
-	public function add_admin_head_style_action() {
-		
-		if ( ! $this->is_screen( 'id', $this->screen_id ) ) {
-			return;
-		}
-
-		do_action( $this->format_head_style_action( 'user' ) );
-	}
-
-	public function add_admin_footer_script_action() {
-		
-		if ( ! $this->is_screen( 'id', $this->screen_id ) ) {
-			return;
-		}
-
-		do_action( $this->format_footer_script_action( 'user' ) );
 	}
 
 }

--- a/includes/class-wp-backstage.php
+++ b/includes/class-wp-backstage.php
@@ -11,76 +11,88 @@ class WP_Backstage {
 	/**
 	 * Slug
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    string
 	 */
 	public $slug = '';
 
 	/**
 	 * Errors
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $errors = array();
 
 	/**
 	 * Screen ID
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    string
 	 */
 	public $screen_id = '';
 
 	/**
-	 * Has Media Uploader
+	 * Has Media
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    bool
 	 */
 	public $has_media = false;
 
 	/**
 	 * Has Date
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    bool
 	 */
 	public $has_date = false;
 
 	/**
 	 * Has Color
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    bool
 	 */
 	public $has_color = false;
+
 	/**
 	 * Has Address
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    bool
 	 */
 	public $has_address = false;
 
 	/**
 	 * Code Editors
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $code_editors = array();
 
 	/**
 	 * Countries
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $countries = array();
 
 	/**
 	 * US States
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $us_states = array();
 
 	/**
 	 * Default Field Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_field_args = array(
 		'type'        => 'text', 
@@ -99,14 +111,16 @@ class WP_Backstage {
 	/**
 	 * Date Format
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    string
 	 */
 	public $date_format = '';
 
 	/**
 	 * Default Option Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_option_args = array(
 		'value'       => '', 
@@ -117,7 +131,8 @@ class WP_Backstage {
 	/**
 	 * Default Media Uploader Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_media_uploader_args = array(
 		'multiple' => false, 
@@ -127,7 +142,8 @@ class WP_Backstage {
 	/**
 	 * Default Date Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_date_args = array(
 		'format' => 'yy-mm-dd', 
@@ -136,7 +152,8 @@ class WP_Backstage {
 	/**
 	 * Default Color Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_color_args = array(
 		'mode'     => '', 
@@ -146,7 +163,8 @@ class WP_Backstage {
 	/**
 	 * Default Code Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_code_args = array(
 		'mime'      => 'text/html', 
@@ -154,18 +172,20 @@ class WP_Backstage {
 	);
 
 	/**
-	 * Default Color Args
+	 * Default Address Args
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_address_args = array(
 		'max_width' => '100%', 
 	);
 
 	/**
-	 * Default Address values
+	 * Default Address Values
 	 * 
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $default_address_values = array(
 		'country'   => 'US', 
@@ -176,6 +196,12 @@ class WP_Backstage {
 		'zip'       => '', 
 	);
 
+	/**
+	 * Remove Label For Fields
+	 * 
+	 * @since  0.0.1
+	 * @var    array
+	 */
 	public $remove_label_for_fields = array( 
 		'radio', 
 		'checkbox_set', 
@@ -183,6 +209,12 @@ class WP_Backstage {
 		'address', 
 	);
 
+	/**
+	 * Non Regular Text Fields
+	 * 
+	 * @since  0.0.1
+	 * @var    array
+	 */
 	public $non_regular_text_fields = array( 
 		'number', 
 		'textarea', 
@@ -197,6 +229,12 @@ class WP_Backstage {
 		'address' 
 	);
 
+	/**
+	 * Textarea Control Fields
+	 * 
+	 * @since  0.0.1
+	 * @var    array
+	 */
 	public $textarea_control_fields = array( 
 		'textarea', 
 		'code', 
@@ -205,7 +243,8 @@ class WP_Backstage {
 	/**
 	 * KSES for P Tags
 	 *
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $kses_p = array(
 		'a' => array(
@@ -247,7 +286,8 @@ class WP_Backstage {
 	/**
 	 * KSES for Label Tags
 	 *
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $kses_label = array(
 		'em' => array(
@@ -275,14 +315,16 @@ class WP_Backstage {
 	/**
 	 * Time Pieces
 	 *
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $time_pieces = array();
 
 	/**
 	 * Global Code Settings
 	 *
-	 * @since 0.0.1
+	 * @since  0.0.1
+	 * @var    array
 	 */
 	public $global_code_settings = array( 
 		'codemirror' => array(
@@ -290,14 +332,18 @@ class WP_Backstage {
 		), 
 	);
 
+	/**
+	 * nonce Key
+	 * 
+	 * @since  0.0.1
+	 * @var    string
+	 */
 	public $nonce_key = '_wp_backstage_nonce';
 
 	/**
 	 * Construct
 	 * 
 	 * @since   0.0.1
-	 * @param   string  $slug 
-	 * @param   array   $args 
 	 * @return  void 
 	 */
 	function __construct() {
@@ -952,7 +998,7 @@ class WP_Backstage {
 	 * Sanitize Text
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a string.
 	 * @return  string  a text field sanitized string. 
 	 */
 	public function sanitize_text( $value = '' ) {
@@ -963,7 +1009,7 @@ class WP_Backstage {
 	 * Sanitize Textarea
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a string.
 	 * @return  string  a textarea sanitized string. 
 	 */
 	public function sanitize_textarea( $value = '' ) {
@@ -974,7 +1020,7 @@ class WP_Backstage {
 	 * Sanitize Code
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a string.
 	 * @return  string  An unsanitized string. 
 	 */
 	public function sanitize_code( $value = '' ) {
@@ -985,7 +1031,7 @@ class WP_Backstage {
 	 * Sanitize Number
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a numeric value.
 	 * @return  float   a float, or null if empty. 
 	 */
 	public function sanitize_number( $value = 0 ) {
@@ -996,7 +1042,7 @@ class WP_Backstage {
 	 * Sanitize URL
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a URL.
 	 * @return  string  A URL. 
 	 */
 	public function sanitize_url( $value = '' ) {
@@ -1007,7 +1053,7 @@ class WP_Backstage {
 	 * Sanitize Email
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects an email address.
 	 * @return  string  An email address. 
 	 */
 	public function sanitize_email( $value = '' ) {
@@ -1018,7 +1064,7 @@ class WP_Backstage {
 	 * Sanitize Checkbox
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a value that can be cast to a boolean.
 	 * @return  bool    A boolean. 
 	 */
 	public function sanitize_checkbox( $value = false ) {
@@ -1029,7 +1075,7 @@ class WP_Backstage {
 	 * Sanitize Checkbox Set
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects an array of values.
 	 * @return  array   An array of values. 
 	 */
 	public function sanitize_checkbox_set( $value = array() ) {
@@ -1040,8 +1086,8 @@ class WP_Backstage {
 	 * Sanitize Address
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
-	 * @return  array   An array of address key, value pairs. 
+	 * @param   $value  The value to sanitize. Expects an array of address key => value pairs.
+	 * @return  array   An array of address key => value pairs. 
 	 */
 	public function sanitize_address( $value = array() ) {
 		return array_map( 'esc_attr', $value );
@@ -1051,7 +1097,7 @@ class WP_Backstage {
 	 * Sanitize Time
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects an array of 3 2-digit time values.
 	 * @return  string   a string as 00:00:00. 
 	 */
 	public function sanitize_time( $value = array() ) {
@@ -1062,7 +1108,7 @@ class WP_Backstage {
 	 * Sanitize Single Media
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects an attachment ID.
 	 * @return  int     An integer, or null if empty. 
 	 */
 	public function sanitize_single_media( $value = 0 ) {
@@ -1073,10 +1119,10 @@ class WP_Backstage {
 	 * Sanitize Multi Media
 	 * 
 	 * @since   0.0.1
-	 * @param   $value  The value to sanitize.
+	 * @param   $value  The value to sanitize. Expects a CSV of attachment IDs.
 	 * @return  array   An array of integers. 
 	 */
-	public function sanitize_multi_media( $value = array() ) {
+	public function sanitize_multi_media( $value = '' ) {
 		return array_map( 'intval', explode( ',', $value ) );
 	}
 
@@ -1084,7 +1130,9 @@ class WP_Backstage {
 	 * Sanitize Field
 	 * 
 	 * @since   0.0.1
-	 * @return  mixed  The sanitized value according to the field type. 
+	 * @param   $field  The field args.
+	 * @param   $value  The field value.
+	 * @return  mixed   The sanitized value according to the field type. 
 	 */
 	public function sanitize_field( $field = array(), $value = null ) {
 

--- a/includes/class-wp-backstage.php
+++ b/includes/class-wp-backstage.php
@@ -1137,9 +1137,6 @@ class WP_Backstage {
 	public function sanitize_field( $field = array(), $value = null ) {
 
 		switch ( $field['type'] ) {
-			case 'text':
-				$value = $this->sanitize_text( $value );
-				break;
 			case 'textarea':
 				$value = $this->sanitize_textarea( $value );
 				break;
@@ -1176,11 +1173,65 @@ class WP_Backstage {
 				}
 				break;
 			default:
-				$value = esc_attr( $value );
+				$value = $this->sanitize_text( $value );
 				break;
 		}
 
 		return $value;
+
+	}
+
+	/**
+	 * Get Sanitize Callback
+	 * 
+	 * @since   0.0.1
+	 * @param   $field  The field args.
+	 * @return  string  The sanitize callback function name as a string. 
+	 */
+	public function get_sanitize_callback( $field = array() ) {
+
+		switch ( $field['type'] ) {
+			case 'textarea':
+				$callback = 'sanitize_textarea';
+				break;
+			case 'code':
+				$callback = 'sanitize_code';
+				break;
+			case 'number':
+				$callback = 'sanitize_number';
+				break;
+			case 'url':
+				$callback = 'sanitize_url';
+				break;
+			case 'email':
+				$callback = 'sanitize_email';
+				break;
+			case 'checkbox':
+				$callback = 'sanitize_checkbox';
+				break;
+			case 'checkbox_set':
+				$callback = 'sanitize_checkbox_set';
+				break;
+			case 'address':
+				$callback = 'sanitize_address';
+				break;
+			case 'time':
+				$callback = 'sanitize_time';
+				break;
+			case 'media':
+				$args = wp_parse_args( $field['args'], $this->default_media_uploader_args );
+				if ( $args['multiple'] ) {
+					$callback = 'sanitize_multi_media';
+				} else {
+					$callback = 'sanitize_single_media';
+				}
+				break;
+			default:
+				$callback = 'sanitize_text';
+				break;
+		}
+
+		return $callback;
 
 	}
 
@@ -1692,7 +1743,6 @@ class WP_Backstage {
 
 		for ($i = 0; $i < $number; $i++) {
 			$option = esc_attr( $i );
-			var_dump( count_chars( $option ) );
 			if ( strlen( $option ) === 1 ) {
 				$option = '0' . $option;
 			}


### PR DESCRIPTION
- Adds more comments. 
- Adds slug var to user class for consistency. 
- This allows for removal of user style and script actions in class in favor of global method. 
- Replaces all instance of 'user' in user class with this->slug.
- Refactors options to register all options rather than serializing by default. 
- Pass group_options_key to serialize. 
- This allows for more normalized API for options.
- Removes commented code and var_dumps.